### PR TITLE
fix: Fix rendering causing stack overflow with deeply nested SVG

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+qt6-svg (6.8.0-0deepin5) unstable; urgency=medium
+
+  * Fix rendering causing stack overflow with deeply nested SVG nodes (CVE-2026-8168).
+  * Fix stack overflow caused by recursive calls of destructors (CVE-2026-8168).
+  * Fix resolving paint servers going through stack overflow (CVE-2026-8168).
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Thu, 28 May 2026 14:55:13 +0800
+
 qt6-svg (6.8.0-0deepin4) unstable; urgency=medium
 
   * Update patch.

--- a/debian/patches/fix-rendering-stack-overflow-with-nested-depth-limit.patch
+++ b/debian/patches/fix-rendering-stack-overflow-with-nested-depth-limit.patch
@@ -1,0 +1,73 @@
+Author: Tian Shilin <tianshilin@uniontech.com>
+Date:   Wed, 22 Apr 2026 13:46:59 +0300
+Subject: Fix rendering causing stack overflow
+Upstream: https://codereview.qt-project.org/c/qt/qtsvg/+/736141
+Bug: QTBUG-145916
+
+Index: qt6-svg/src/svg/qsvgnode.cpp
+===================================================================
+--- qt6-svg.orig/src/svg/qsvgnode.cpp
++++ qt6-svg/src/svg/qsvgnode.cpp
+@@ -42,6 +42,16 @@ void QSvgNode::draw(QPainter *p, QSvgExt
+ #endif
+ 
+     if (shouldDrawNode(p, states)) {
++        quint8 remainingDepth = states.trustedSource ? states.remainingNestedNodes
++                                                     : states.remainingNestedNodes - 1;
++        QScopedValueRollback<quint8> nestedNodesGuard(states.remainingNestedNodes, remainingDepth);
++        if (states.remainingNestedNodes == 0) {
++            qCWarning(lcSvgDraw) << "Too many nested nodes at" << qPrintable(typeName())
++                                 << "exceeding max nested limit of" << QtSvg::renderingMaxNestedNodes << "."
++                                 << "Enable AssumeTrustedSource in QSvgHandler or set QT_SVG_DEFAULT_OPTIONS=2 to disable this check.";
++            return;
++        }
++
+         applyStyle(p, states);
+         QSvgNode *maskNode = this->hasMask() ? document()->namedNode(this->maskId()) : nullptr;
+         QSvgFilterContainer *filterNode = this->hasFilter() ? static_cast<QSvgFilterContainer*>(document()->namedNode(this->filterId()))
+@@ -625,7 +635,7 @@ bool QSvgNode::shouldDrawNode(QPainter *
+     if (m_displayMode == DisplayMode::NoneMode)
+         return false;
+ 
+-    if (document() && document()->options().testFlag(QtSvg::AssumeTrustedSource))
++    if (document() && states.trustedSource)
+         return true;
+ 
+     QRectF brect = internalFastBounds(p, states);
+Index: qt6-svg/src/svg/qsvgstyle_p.h
+===================================================================
+--- qt6-svg.orig/src/svg/qsvgstyle_p.h
++++ qt6-svg/src/svg/qsvgstyle_p.h
+@@ -115,6 +115,8 @@ struct Q_SVG_EXPORT QSvgExtraStates
+     qreal strokeDashOffset;
+     int nestedUseLevel = 0;
+     int nestedUseCount = 0;
++    bool trustedSource = false;
++    quint8 remainingNestedNodes = QtSvg::renderingMaxNestedNodes;
+     bool vectorEffect; // true if pen is cosmetic
+     qint8 imageRendering; // QSvgQualityStyle::ImageRendering
+     bool inUse = false; // true if currently in QSvgUseNode
+Index: qt6-svg/src/svg/qtsvgglobal_p.h
+===================================================================
+--- qt6-svg.orig/src/svg/qtsvgglobal_p.h
++++ qt6-svg/src/svg/qtsvgglobal_p.h
+@@ -28,6 +28,7 @@ enum class UnitTypes : quint32 {
+     userSpaceOnUse
+ };
+ 
++constexpr quint8 renderingMaxNestedNodes = 32;
+ }
+ 
+ QT_END_NAMESPACE
+Index: qt6-svg/src/svg/qsvgtinydocument.cpp
+===================================================================
+--- qt6-svg.orig/src/svg/qsvgtinydocument.cpp
++++ qt6-svg/src/svg/qsvgtinydocument.cpp
+@@ -33,6 +33,7 @@ QSvgTinyDocument::QSvgTinyDocument(QtSvg
+     , m_fps(30)
+     , m_options(options)
+ {
++    m_states.trustedSource = m_options.testFlag(QtSvg::AssumeTrustedSource);
+ }
+ 
+ QSvgTinyDocument::~QSvgTinyDocument()

--- a/debian/patches/fix-resolving-paint-servers-stack-overflow.patch
+++ b/debian/patches/fix-resolving-paint-servers-stack-overflow.patch
@@ -1,0 +1,208 @@
+Author: Tian Shilin <tianshilin@uniontech.com>
+Date:   Wed, 22 Apr 2026 08:57:44 +0300
+Subject: Fix resolving paint servers going through stack overflow
+Upstream: https://codereview.qt-project.org/c/qt/qtsvg/+/730501
+Bug: QTBUG-145916
+
+Index: qt6-svg/src/svg/qsvghandler.cpp
+===================================================================
+--- qt6-svg.orig/src/svg/qsvghandler.cpp
++++ qt6-svg/src/svg/qsvghandler.cpp
+@@ -1036,7 +1036,7 @@ static void parseBrush(QSvgNode *node,
+                 } else {
+                     QString id = idFromUrl(value);
+                     prop->setPaintStyleId(id);
+-                    prop->setPaintStyleResolved(false);
++                    handler->pushUnresolvedStyle(prop);
+                 }
+             } else if (attributes.fill != QLatin1String("none")) {
+                 QColor color;
+@@ -1206,7 +1206,7 @@ static void parsePen(QSvgNode *node,
+                     } else {
+                         QString id = idFromUrl(value);
+                         prop->setPaintStyleId(id);
+-                        prop->setPaintStyleResolved(false);
++                        handler->pushUnresolvedStyle(prop);
+                     }
+             } else if (attributes.stroke != QLatin1String("none")) {
+                 QColor color;
+@@ -4668,7 +4668,7 @@ void QSvgHandler::parse()
+             break;
+         }
+     }
+-    resolvePaintServers(m_doc);
++    resolvePaintServers();
+     resolveNodes();
+     if (detectCycles(m_doc)) {
+         qCWarning(lcSvgHandler, "Cycles detected in SVG, document discarded.");
+@@ -4902,33 +4902,23 @@ bool QSvgHandler::endElement(const QStri
+     return ((localName == QLatin1String("svg")) && (node != Doc));
+ }
+ 
+-void QSvgHandler::resolvePaintServers(QSvgNode *node, int nestedDepth)
++void QSvgHandler::resolvePaintServers()
+ {
+-    if (!node || (node->type() != QSvgNode::Doc && node->type() != QSvgNode::Group
+-        && node->type() != QSvgNode::Defs && node->type() != QSvgNode::Switch)) {
+-        return;
+-    }
+-
+-    QSvgStructureNode *structureNode = static_cast<QSvgStructureNode *>(node);
+-
+-    const QList<QSvgNode *> ren = structureNode->renderers();
+-    for (auto it = ren.begin(); it != ren.end(); ++it) {
+-        QSvgFillStyle *fill = static_cast<QSvgFillStyle *>((*it)->styleProperty(QSvgStyleProperty::FILL));
+-        if (fill && !fill->isPaintStyleResolved()) {
++    for (QSvgStyleProperty *prop : std::as_const(m_unresolvedStyles)) {
++        if (prop->type() == QSvgStyleProperty::FILL) {
++            QSvgFillStyle *fill = static_cast<QSvgFillStyle *>(prop);
+             QString id = fill->paintStyleId();
+-            QSvgPaintStyleProperty *style = structureNode->styleProperty(id);
++            QSvgPaintStyleProperty *style = m_doc->namedStyle(id);
+             if (style) {
+                 fill->setFillStyle(style);
+             } else {
+                 qCWarning(lcSvgHandler, "%s", msgCouldNotResolveProperty(id, xml).constData());
+                 fill->setBrush(Qt::NoBrush);
+             }
+-        }
+-
+-        QSvgStrokeStyle *stroke = static_cast<QSvgStrokeStyle *>((*it)->styleProperty(QSvgStyleProperty::STROKE));
+-        if (stroke && !stroke->isPaintStyleResolved()) {
++        } else if (prop->type() == QSvgStyleProperty::STROKE) {
++            QSvgStrokeStyle *stroke = static_cast<QSvgStrokeStyle *>(prop);
+             QString id = stroke->paintStyleId();
+-            QSvgPaintStyleProperty *style = structureNode->styleProperty(id);
++            QSvgPaintStyleProperty *style = m_doc->namedStyle(id);
+             if (style) {
+                 stroke->setStyle(style);
+             } else {
+@@ -4936,10 +4926,9 @@ void QSvgHandler::resolvePaintServers(QS
+                 stroke->setStroke(Qt::NoBrush);
+             }
+         }
+-
+-        if (nestedDepth < 2048)
+-            resolvePaintServers(*it, nestedDepth + 1);
+     }
++
++    m_unresolvedStyles.clear();
+ }
+ 
+ void QSvgHandler::resolveNodes()
+@@ -5055,6 +5044,11 @@ QColor QSvgHandler::currentColor() const
+         return QColor(0, 0, 0);
+ }
+ 
++void QSvgHandler::pushUnresolvedStyle(QSvgStyleProperty *prop)
++{
++    m_unresolvedStyles.append(prop);
++}
++
+ #ifndef QT_NO_CSSPARSER
+ 
+ void QSvgHandler::setInStyle(bool b)
+Index: qt6-svg/src/svg/qsvghandler_p.h
+===================================================================
+--- qt6-svg.orig/src/svg/qsvghandler_p.h
++++ qt6-svg/src/svg/qsvghandler_p.h
+@@ -82,6 +82,8 @@ public:
+     void popColor();
+     QColor currentColor() const;
+ 
++    void pushUnresolvedStyle(QSvgStyleProperty *prop);
++
+ #ifndef QT_NO_CSSPARSER
+     void setInStyle(bool b);
+     bool inStyle() const;
+@@ -118,6 +120,7 @@ private:
+     // - <use> nodes which haven't been resolved yet.
+     // - <filter> nodes to be checked for unsupported filter primitives.
+     QList<QSvgNode *> m_toBeResolved;
++    QList<QSvgStyleProperty *> m_unresolvedStyles;
+ 
+     enum CurrentNode
+     {
+@@ -150,7 +153,7 @@ private:
+     QCss::Parser m_cssParser;
+ #endif
+     void parse();
+-    void resolvePaintServers(QSvgNode *node, int nestedDepth = 0);
++    void resolvePaintServers();
+     void resolveNodes();
+ 
+     QPen m_defaultPen;
+Index: qt6-svg/src/svg/qsvgstyle.cpp
+===================================================================
+--- qt6-svg.orig/src/svg/qsvgstyle.cpp
++++ qt6-svg/src/svg/qsvgstyle.cpp
+@@ -94,7 +94,6 @@ QSvgFillStyle::QSvgFillStyle()
+     , m_oldFillRule(Qt::WindingFill)
+     , m_fillOpacity(1.0)
+     , m_oldFillOpacity(0)
+-    , m_paintStyleResolved(1)
+     , m_fillRuleSet(0)
+     , m_fillOpacitySet(0)
+     , m_fillSet(0)
+@@ -249,7 +248,6 @@ QSvgStrokeStyle::QSvgStrokeStyle()
+     , m_strokeDashOffset(0)
+     , m_oldStrokeDashOffset(0)
+     , m_style(0)
+-    , m_paintStyleResolved(1)
+     , m_vectorEffect(0)
+     , m_oldVectorEffect(0)
+     , m_strokeSet(0)
+Index: qt6-svg/src/svg/qsvgstyle_p.h
+===================================================================
+--- qt6-svg.orig/src/svg/qsvgstyle_p.h
++++ qt6-svg/src/svg/qsvgstyle_p.h
+@@ -255,16 +255,6 @@ public:
+         return m_paintStyleId;
+     }
+ 
+-    void setPaintStyleResolved(bool resolved)
+-    {
+-        m_paintStyleResolved = resolved;
+-    }
+-
+-    bool isPaintStyleResolved() const
+-    {
+-        return m_paintStyleResolved;
+-    }
+-
+ private:
+     // fill            v 	v 	'inherit' | <Paint.datatype>
+     // fill-opacity    v 	v 	'inherit' | <OpacityValue.datatype>
+@@ -278,7 +268,6 @@ private:
+     qreal m_oldFillOpacity;
+ 
+     QString m_paintStyleId;
+-    uint m_paintStyleResolved : 1;
+ 
+     uint m_fillRuleSet : 1;
+     uint m_fillOpacitySet : 1;
+@@ -479,16 +468,6 @@ public:
+         return m_paintStyleId;
+     }
+ 
+-    void setPaintStyleResolved(bool resolved)
+-    {
+-        m_paintStyleResolved = resolved;
+-    }
+-
+-    bool isPaintStyleResolved() const
+-    {
+-        return m_paintStyleResolved;
+-    }
+-
+     QPen stroke() const
+     {
+         return m_stroke;
+@@ -512,7 +491,6 @@ private:
+ 
+     QSvgPaintStyleProperty *m_style;
+     QString m_paintStyleId;
+-    uint m_paintStyleResolved : 1;
+     uint m_vectorEffect : 1;
+     uint m_oldVectorEffect : 1;
+ 

--- a/debian/patches/fix-stack-overflow-caused-by-recursive-destructors.patch
+++ b/debian/patches/fix-stack-overflow-caused-by-recursive-destructors.patch
@@ -1,0 +1,85 @@
+Author: Tian Shilin <tianshilin@uniontech.com>
+Date:   Fri, 24 Apr 2026 10:11:37 +0300
+Subject: Fix stack overflow caused by recursive calls of destructors
+Upstream: https://codereview.qt-project.org/c/qt/qtsvg/+/736142
+Bug: QTBUG-145916
+
+Index: qt6-svg/src/svg/qsvgstructure.cpp
+===================================================================
+--- qt6-svg.orig/src/svg/qsvgstructure.cpp
++++ qt6-svg/src/svg/qsvgstructure.cpp
+@@ -604,6 +604,44 @@ QSvgNode* QSvgStructureNode::previousSib
+     return prev;
+ }
+ 
++void QSvgStructureNode::releaseDescendants()
++{
++    // This function will release the descendants of a QSvgStructureNode from bottom to top.
++    // Destructors are never called recursively in this case and stack overflow will not
++    // happen in deeply nested trees.
++    // This function does not allocate any memory at the cost of sacrificing some performance to
++    // make it safe to be called from a destructor.
++    while (!m_renderers.empty()) {
++        auto nodes = &m_renderers;
++        bool isSubtree = true;
++        while (isSubtree) {
++            switch (nodes->front()->type()) {
++            case QSvgNode::Doc:
++            case QSvgNode::Defs:
++            case QSvgNode::Group:
++            case QSvgNode::Mask:
++            case QSvgNode::Pattern:
++            case QSvgNode::Symbol:
++            case QSvgNode::Switch:
++            case QSvgNode::Filter:
++            {
++                QSvgStructureNode *subtree = static_cast<QSvgStructureNode *>(nodes->first());
++                isSubtree = !subtree->m_renderers.empty();
++                if (isSubtree)
++                    nodes = &subtree->m_renderers;
++            }
++                break;
++            default:
++                isSubtree = false;
++                break;
++            }
++        }
++        QSvgNode *node = nodes->first();
++        delete node;
++        nodes->pop_front();
++    }
++}
++
+ QSvgMask::QSvgMask(QSvgNode *parent, QSvgRectF bounds,
+                    QtSvg::UnitTypes contentUnits)
+     : QSvgStructureNode(parent)
+Index: qt6-svg/src/svg/qsvgstructure_p.h
+===================================================================
+--- qt6-svg.orig/src/svg/qsvgstructure_p.h
++++ qt6-svg/src/svg/qsvgstructure_p.h
+@@ -37,6 +37,10 @@ public:
+     QRectF internalBounds(QPainter *p, QSvgExtraStates &states) const override;
+     QSvgNode *previousSiblingNode(QSvgNode *n) const;
+     QList<QSvgNode*> renderers() const { return m_renderers; }
++
++protected:
++    void releaseDescendants();
++
+ protected:
+     QList<QSvgNode*>          m_renderers;
+     QHash<QString, QSvgNode*> m_scope;
+Index: qt6-svg/src/svg/qsvgtinydocument.cpp
+===================================================================
+--- qt6-svg.orig/src/svg/qsvgtinydocument.cpp
++++ qt6-svg/src/svg/qsvgtinydocument.cpp
+@@ -37,6 +37,10 @@ QSvgTinyDocument::QSvgTinyDocument(QtSvg
+ 
+ QSvgTinyDocument::~QSvgTinyDocument()
+ {
++    // Only do that when AssumeTrustedSource is set to false. Otherwise, all nodes
++    // will be deleted by recursive calls of destructors.
++    if (!m_states.trustedSource)
++        releaseDescendants();
+ }
+ 
+ static bool hasSvgHeader(const QByteArray &buf)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,6 @@
 Replace-check-for-endless-recursion-when-loading.patch
 Do-not-create-group-nodes-which-will-be-deleted-anyway.patch
 CVE-2026-6210-test-types-of-nodes-before-downcasting-them.patch
+fix-rendering-stack-overflow-with-nested-depth-limit.patch
+fix-stack-overflow-caused-by-recursive-destructors.patch
+fix-resolving-paint-servers-stack-overflow.patch


### PR DESCRIPTION
log: With a deeply nested svg document, the process will run out of stack if the stack is limited. To fix this, a limit to the number of nested elements (max 32) is used to stop rendering if the current nested level exceeds the max limit.

upstream: https://codereview.qt-project.org/c/qt/qtsvg/+/730591